### PR TITLE
Query metrics per hour instead of per second in the metrics and countries endpoint.

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -153,7 +153,11 @@ function getActivity (parameters) {
 }
 
 function getCountries (parameters) {
-  let query = Map({name: 'request', by: 'country'})
+  let query = Map({
+    name: 'request',
+    by: 'country',
+    step: 3600
+  })
   query = readParameters(query, parameters)
   if (parameters.type) {
     query = query.setIn(['tags', 'type'], parameters.type)
@@ -167,7 +171,10 @@ function getCountries (parameters) {
 }
 
 function getMetrics (parameters) {
-  let query = Map({name: 'request'})
+  let query = Map({
+    name: 'request',
+    step: 3600
+  })
   query = readParameters(query, parameters)
   return Map({
     requests: countAndSpeed(db.query(query)),


### PR DESCRIPTION
I think the problem was that the time series database returned an immutable Map with 86,400 entries and we summed up the result with a reduce in `dashboard/app`. By sending the `step` parameter we reduce this Map to 24 entries.