### PR TITLE
Watermark

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -65,13 +65,6 @@ function forward (stream, event) {
 }
 
 /**
- * Identity stream transformer.
- */
-function identity () {
-  return (stream) => stream
-}
-
-/**
  * Applies `f` to each event.
  *
  * `f` can return an event or a Promise of an event.

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -65,6 +65,13 @@ function forward (stream, event) {
 }
 
 /**
+ * Identity stream transformer.
+ */
+function identity () {
+  return (stream) => stream
+}
+
+/**
  * Applies `f` to each event.
  *
  * `f` can return an event or a Promise of an event.
@@ -135,17 +142,6 @@ function by (f, xf) {
   }
 }
 
-/**
- * Compute and assign the watermark to the event.
- */
-function watermark (delay) {
-  return (stream) => {
-    return (event) => {
-      forward(stream, event.set('watermark', now() - delay))
-    }
-  }
-}
-
 // Holds the state of the windows
 let windows = List()
 let id = 0
@@ -156,18 +152,16 @@ const nextId = () => id++
  *
  * If the stream is split (`by` was called), maintain a different window for each key.
  */
-function window ({strategy, reducer, allowedLateness, fireEvery}) {
+function window ({strategy, reducer, allowedLateness, fireEvery, watermarkDelay = 5}) {
   const id = nextId()
   return (stream) => {
     return (event) => {
       // Drop late events
       const t = event.get('time')
-      const watermark = event.get('watermark')
+      const watermark = now() - watermarkDelay
       if (t < watermark - allowedLateness) {
         console.log('WARNING', 'Dropping late event.')
-        console.log('Watermark:', iso(watermark),
-                    'Event time:', iso(t),
-                    'Delta:', t - watermark)
+        console.log('Watermark:', iso(watermark), 'Event time:', iso(t), 'Delta:', t - watermark)
         return
       }
       windows = windows.updateIn([id, event.get('key')], Map(), windows => {
@@ -378,8 +372,8 @@ class InputMonitor {
 }
 
 class Pipeline extends Builder {
-  constructor ({delay = 5} = {}) {
-    super(watermark(delay))
+  constructor () {
+    super(identity())
     this.inputs = []
     this.monitors = []
     this.stream = null

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -139,18 +139,9 @@ function by (f, xf) {
  * Compute and assign the watermark to the event.
  */
 function watermark (delay) {
-  let watermark
-  let lastEventReceivedAt
   return (stream) => {
     return (event) => {
-      if (!watermark) {
-        watermark = event.get('time') - delay
-        lastEventReceivedAt = now()
-      } else {
-        watermark += now() - lastEventReceivedAt
-        lastEventReceivedAt = now()
-      }
-      forward(stream, event.set('watermark', watermark))
+      forward(stream, event.set('watermark', now() - delay))
     }
   }
 }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -387,8 +387,8 @@ class InputMonitor {
 }
 
 class Pipeline extends Builder {
-  constructor () {
-    super(watermark(5))
+  constructor ({delay = 5} = {}) {
+    super(watermark(delay))
     this.inputs = []
     this.monitors = []
     this.stream = null

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -10,7 +10,7 @@
  * This modules provides functions to build a pipeline, a tree of stream processors.
  */
 const { Map, List } = require('immutable')
-const { now, complement } = require('./util')
+const { now, complement, iso } = require('./util')
 const metrics = require('./metrics')
 const session = require('./session')
 
@@ -142,6 +142,26 @@ function by (f, xf) {
   }
 }
 
+/**
+ * Compute and assign the watermark to the event.
+ */
+function watermark (delay) {
+  let watermark
+  let lastEventReceivedAt
+  return (stream) => {
+    return (event) => {
+      if (!watermark) {
+        watermark = event.get('time') - delay
+        lastEventReceivedAt = now()
+      } else {
+        watermark += now() - lastEventReceivedAt
+        lastEventReceivedAt = now()
+      }
+      forward(stream, event.set('watermark', watermark))
+    }
+  }
+}
+
 // Holds the state of the windows
 let windows = List()
 let id = 0
@@ -154,29 +174,16 @@ const nextId = () => id++
  */
 function window ({strategy, reducer, allowedLateness, fireEvery}) {
   const id = nextId()
-  let watermark
-  let watermarkTime
   return (stream) => {
     return (event) => {
-      // Update watermark
-      const t = event.get('time')
-      if (!watermark) {
-        watermark = t
-        watermarkTime = now()
-      } else {
-        let watermarkCandidate = Math.max(watermark, t)
-        let watermarkDelta = watermarkCandidate - watermark
-        let timeDelta = now() - watermarkTime
-        if (watermarkDelta - timeDelta > 60) {
-          console.log('Dropping event in the future. The event was ' + watermarkDelta + ' seconds ahead of the previous one.')
-          return
-        }
-        watermark = watermarkCandidate
-        watermarkTime = now()
-      }
       // Drop late events
+      const t = event.get('time')
+      const watermark = event.get('watermark')
       if (t < watermark - allowedLateness) {
         console.log('WARNING', 'Dropping late event.')
+        console.log('Watermark:', iso(watermark),
+                    'Event time:', iso(t),
+                    'Delta:', t - watermark)
         return
       }
       windows = windows.updateIn([id, event.get('key')], Map(), windows => {
@@ -388,7 +395,7 @@ class InputMonitor {
 
 class Pipeline extends Builder {
   constructor () {
-    super(identity())
+    super(watermark(5))
     this.inputs = []
     this.monitors = []
     this.stream = null


### PR DESCRIPTION
The watermark represents when (in processing time) we can consider that we received all events before a given event time.

Because of the latency of the various systems between the user's web server and the access watch pipeline, we need to introduce a delay of a few seconds before considering that we received all events for a given timestamp.

By default, the delay is 5 seconds but the user can change it when creating the window.

Late events will generate a warning on the console:

```
WARNING Dropping late event.
Watermark: 2017-11-15T16:38:36Z Event time: 2017-11-15T05:38:41Z Delta: -39595
```