### PR TITLE
Revert "Fix #51: Set end to now() by default."

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -8,7 +8,7 @@ const session = require('./session').getDatabase('traffic')
 const rules = require('./rules').getDatabase('traffic')
 
 const pipeline = require('./pipeline')
-const { now, iso } = require('./util')
+const { iso } = require('./util')
 
 const app = express()
 
@@ -70,8 +70,6 @@ function parseRequest (req) {
   }
   if (req.query.end) {
     query = query.set('end', parseTimestamp(req.query, 'end'))
-  } else {
-    query = query.set('end', now())
   }
   if (req.query.step) {
     query = query.set('step', parsePosInt(req.query, 'step'))


### PR DESCRIPTION
Reverts access-watch/access-watch#53

This is not working in the current state. Some metrics queries are empty while they should not. 

Eg:
http://localhost:3000/metrics/request?step=86400&by=type
