### PR TITLE
Fix #50: Apache Log Format

### DIFF
--- a/format/apache.js
+++ b/format/apache.js
@@ -1,0 +1,86 @@
+const { fromJS, Map, List } = require('immutable')
+const strptime = require('micro-strptime').strptime
+
+function compile (format) {
+  const parts = format.split(/(%[^ "]+)/)
+
+  const matchString = ([head, ...tail], text) => {
+    if (text.startsWith(head)) {
+      if (tail.length === 0) {
+        return Map()
+      }
+      return matchVariable(tail, text.substring(head.length))
+    } else {
+      throw new Error(`Syntax error. Was expecting the string ${head}. Got: ${text}`)
+    }
+  }
+
+  const matchVariable = ([head, ...tail], text) => {
+    const len = text.indexOf(tail[0])
+    if (len !== -1) {
+      const value = text.substring(0, len)
+      return matchString(tail, text.substring(len)).set(head, value)
+    } else {
+      throw new Error(`Syntax error. Was expecting the variable ${head}. Got ${text}.`)
+    }
+  }
+
+  return s => {
+    return matchString(parts, s)
+  }
+}
+
+function addRequest (log, request) {
+  const res = /([^ ]+)\s+([^ ]+)\s+([^ ]+)/.exec(request)
+  if (res) {
+    return log
+      .setIn(['request', 'method'], res[1])
+      .setIn(['request', 'url'], res[2])
+      .setIn(['request', 'protocol'], res[3])
+  }
+  return log
+}
+
+function parseTime (value) {
+  value = value.substring(1, value.length - 1) // remove '[' and ']'
+  return strptime(value, '%d/%B/%Y:%H:%M:%S %z').toISOString()
+}
+
+const transformers = {
+  '%h': (log, value) => log.setIn(['request', 'address'], value),
+  '%t': (log, value) => log.setIn(['request', 'time'], parseTime(value)),
+  '%r': addRequest,
+  '%>s': (log, value) => log.setIn(['response', 'status'], parseInt(value))
+}
+
+function parser ({format}) {
+  const p = compile(format)
+  return (msg) => {
+    return p(msg).reduce((log, v, k) => {
+      const transform = transformers[k.toLowerCase()]
+      if (transform) {
+        return transform(log, v)
+      }
+      const header = k.match(/%\{([^}]+)\}i/)
+      if (header) {
+        const name = header[1].toLowerCase()
+        log = log.updateIn(['request', 'captured_headers'], List(), coll => coll.push(name))
+        if (v === '-') {
+          return log
+        }
+        return log.setIn(['request', 'headers', name], v)
+      }
+      return log
+    }, fromJS({request: {headers: {}}}))
+  }
+}
+
+const formats = {
+  combined: '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"',
+  accessWatch: '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i" "%{Accept}i" "%{Accept-Charset}i" "%{Accept-Encoding}i" "%{Accept-Language}i" "%{Connection}i" "%{Dnt}i" "%{From}i" "%{Host}i"'
+}
+
+module.exports = {
+  formats: formats,
+  parser: parser
+}

--- a/format/index.js
+++ b/format/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   nginx: require('./nginx'),
+  apache: require('./apache'),
   logstash: require('./logstash'),
   expressBunyanLogger: require('./express-bunyan-logger')
 }

--- a/format/nginx.js
+++ b/format/nginx.js
@@ -17,7 +17,7 @@ function compile (format) {
       }
       return matchVariable(tail, text.substring(head.length))
     } else {
-      throw new Error('Syntax error at ' + text)
+      throw new Error(`Syntax error. Was expecting the string ${head}. Got: ${text}`)
     }
   }
 
@@ -27,7 +27,7 @@ function compile (format) {
       const value = text.substring(0, len)
       return matchString(tail, text.substring(len)).set(head, value)
     } else {
-      throw new Error('Syntax error at ' + text)
+      throw new Error(`Syntax error. Was expecting the variable ${head}. Got ${text}.`)
     }
   }
 

--- a/format/nginx.js
+++ b/format/nginx.js
@@ -97,7 +97,8 @@ function parser ({format = formats.combined,
 
 const formats = {
   combined: '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent"',
-  accessWatch: '"$time_iso8601" "$remote_addr" "$http_host" "$request" $status "$http_user_agent" "$http_accept" "$http_accept_language" "$http_accept_charset" "$http_accept_encoding" "$http_from" "$http_dnt" "$http_connection" "$http_referer"'
+  accessWatch: '"$time_iso8601" "$remote_addr" "$http_host" "$request" $status "$http_user_agent" "$http_accept" "$http_accept_language" "$http_accept_charset" "$http_accept_encoding" "$http_from" "$http_dnt" "$http_connection" "$http_referer"',
+  accessWatchCombined: '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent" "$http_accept" "$http_accept_charset" "$http_accept_encoding" "$http_accept_language" "$http_connection" "$http_dnt" "$http_from" "$http_host"'
 }
 
 module.exports = {

--- a/test/format/apache.js
+++ b/test/format/apache.js
@@ -1,0 +1,79 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const apache = require('../../format/apache.js')
+
+const cases = [
+  {
+    name: 'should parse a log according to the combined format',
+    options: {
+      format: '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"'
+    },
+    msg: '127.0.0.1 - - [27/Jan/2016:11:43:30 -0600] "GET /js/out/goog/asserts/asserts.js HTTP/1.1" 200 3480 "http://localhost:8080/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36"',
+    expected: {
+      request: {
+        address: '127.0.0.1',
+        time: '2016-01-27T17:43:30.000Z',
+        method: 'GET',
+        url: '/js/out/goog/asserts/asserts.js',
+        protocol: 'HTTP/1.1',
+        captured_headers: ['referer', 'user-agent'],
+        headers: {
+          referer: 'http://localhost:8080/',
+          'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36'
+        }
+      },
+      response: {
+        status: 200
+      }
+    }
+  },
+  {
+    name: 'should parse a log according to the Access Watch format',
+    options: {
+      format: '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i" "%{Accept}i" "%{Accept-Charset}i" "%{Accept-Encoding}i" "%{Accept-Language}i" "%{Connection}i" "%{Dnt}i" "%{From}i" "%{Host}i"'
+    },
+    msg: '127.0.0.1 - - [27/Jan/2016:11:43:30 -0600] "GET / HTTP/1.1" 304 3480 "http://localhost:8080/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36" "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8" "en-US,en;q=0.8,fil;q=0.6,fr;q=0.4,es;q=0.2" "-" "gzip, deflate, br" "-" "-" "keep-alive" "-"',
+    expected: {
+      request: {
+        address: '127.0.0.1',
+        captured_headers: [
+          'dnt',
+          'connection',
+          'referer',
+          'user-agent',
+          'accept-charset',
+          'accept',
+          'host',
+          'from',
+          'accept-encoding',
+          'accept-language'
+        ],
+        headers: {
+          accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
+          'accept-charset': 'en-US,en;q=0.8,fil;q=0.6,fr;q=0.4,es;q=0.2',
+          'accept-language': 'gzip, deflate, br',
+          from: 'keep-alive',
+          referer: 'http://localhost:8080/',
+          'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36'
+        },
+        method: 'GET',
+        protocol: 'HTTP/1.1',
+        time: '2016-01-27T17:43:30.000Z',
+        url: '/'
+      },
+      response: {
+        status: 304
+      }
+    }
+  }
+]
+
+describe('Apache format', function () {
+  cases.map(({name, options, msg, expected}) => {
+    it(name, function () {
+      const parse = apache.parser(options)
+      assert.deepEqual(parse(msg).toJS(), expected)
+    })
+  })
+})


### PR DESCRIPTION
Basic support for Apache log format.

Do not handle edge cases like custom time formats but is enough to parse logs in the standard combined log format and the Access Watch log format.

See http://httpd.apache.org/docs/current/mod/mod_log_config.html