### PR TITLE
Fix #64: Do not return speed if we don't have it.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -2,7 +2,7 @@
  * Database of user and bot sessions.
  */
 
-const { Map, Repeat, List } = require('immutable')
+const { Map, Range } = require('immutable')
 const { iso, now } = require('./util')
 
 /**
@@ -11,48 +11,27 @@ const { iso, now } = require('./util')
 class Speed {
   constructor (size) {
     this.size = size
-    this.counters = []
+    this.counters = {}
   }
 
-  // count the request for the given `time`
   hit (time) {
-    const cutoff = now() - this.size * 60
-    this.counters = this.counters.filter(([t, v]) => t >= cutoff)
-    const lastIndex = this.counters.length - 1
-    if (lastIndex === -1 || this.counters[lastIndex][0] < time) {
-      this.counters.push([time, 1])
+    const idx = time - time % 60
+    if (this.counters[idx] === undefined) {
+      this.counters[idx] = 1
     } else {
-      for (var i = lastIndex; i >= 0; i--) {
-        if (this.counters[i][0] < time) {
-          this.counters.splice(i + 1, 0, [time, 1])
-          return this
-        } else if (this.counters[i][0] === time) {
-          this.counters[i][1]++
-          return this
-        }
-      }
-      this.counters.unshift([time, 1])
+      this.counters[idx]++
     }
     return this
   }
 
-  // compute speed for the last `size` minutes
   compute () {
-    let speeds = Repeat(0, this.size)
-    const lastIndex = this.counters.length - 1
-    if (lastIndex === -1) {
-      return speeds
-    }
-    speeds = speeds.toJS()
-    const end = now()
-    const start = end - this.size * 60
-    for (var i = lastIndex; i >= 0; i--) {
-      const time = this.counters[i][0]
-      if (start <= time && time < end) {
-        speeds[Math.floor((end - time) / 60)] += this.counters[i][1]
-      }
-    }
-    return List(speeds)
+    const time = now()
+    const currentMinute = time - time % 60
+    return Range(0, this.size)
+      .map(n => {
+        return this.counters[currentMinute - n * 60]
+      })
+      .filter(c => c !== undefined)
   }
 }
 


### PR DESCRIPTION
Simplify the computation of the session speed and do not return 0 if we do not know the speed.

We now return an array of at most 15 entries. But they contain the number of requests for each minute bucket. So the first entry contains the number of requests for the current minute, the second for the minute that has passed...

So the first number is not really interesting because it will always be partial. It might just be useful for the first minute when starting the application to show the partial speed for the current minute.

After that, the indices from 1 to 14 contain the number of requests for the past minutes. Those should be fixed and can be used to compute average speed.

If you think we can wait a minute before showing the speed in the dashboard, I can get rid of the first entry and only return "completed entries". Let me know what you think.
