### PR TITLE
TCP Socket/Syslog

### DIFF
--- a/input/index.js
+++ b/input/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   http: require('./http'),
   syslog: require('./syslog'),
+  socket: require('./socket'),
   file: require('./file'),
   elasticsearch: require('./elasticsearch'),
   websocket: require('./websocket')

--- a/input/socket.js
+++ b/input/socket.js
@@ -1,0 +1,70 @@
+const dgram = require('dgram')
+const net = require('net')
+
+const { fromJS } = require('immutable')
+
+const defaultParse = s => fromJS(JSON.parse(s))
+
+function createTcpServer ({pipeline, name, port, handler}) {
+  return net
+    .createServer(socket => {
+      socket.on('data', data => {
+        data.toString().split('\n').forEach(line => {
+          if (line) {
+            handler(line)
+          }
+        })
+      })
+    })
+    .listen(port, err => {
+      if (err) {
+        pipeline.status(err, 'Cannot start: ' + err.message)
+      } else {
+        pipeline.status(null, `Listening on port ${port}.`)
+        console.log(`${name} listening on TCP port ${port}.`)
+      }
+    })
+}
+
+function createUdpServer ({pipeline, name, port, handler}) {
+  return dgram
+    .createSocket('udp4')
+    .on('message', message => {
+      handler(message.toString())
+    })
+    .on('error', err => {
+      pipeline.status(err, 'Cannot start: ' + err.message)
+    })
+    .on('listening', () => {
+      pipeline.status(null, `Listening on port ${port}.`)
+      console.log(`${name} listening on UDP port ${port}.`)
+    })
+    .bind(port)
+}
+
+function create ({name = 'Socket', protocol, port, parse = defaultParse}) {
+  return {
+    name: name,
+    start: pipeline => {
+      const handler = message => {
+        try {
+          pipeline.success(parse(message))
+        } catch (err) {
+          pipeline.error(err)
+        }
+      }
+      if (!protocol || protocol === 'udp') {
+        createUdpServer({pipeline, name, port, handler})
+      }
+      if (!protocol || protocol === 'tcp') {
+        createTcpServer({pipeline, name, port, handler})
+      }
+    }
+  }
+}
+
+module.exports = {
+  createTcpServer,
+  createUdpServer,
+  create
+}

--- a/input/syslog.js
+++ b/input/syslog.js
@@ -1,56 +1,8 @@
-const net = require('net')
-const dgram = require('dgram')
-
 const syslogParse = require('syslog-parse')
 
 const { fromJS } = require('immutable')
 
-function createTcpServer ({pipeline, name, port, parse}) {
-  return net
-    .createServer(socket => {
-      socket.on('data', data => {
-        data.toString().split('\n').forEach(line => {
-          if (line) {
-            try {
-              const result = syslogParse(line)
-              pipeline.success(parse(result.message))
-            } catch (err) {
-              pipeline.error(err)
-            }
-          }
-        })
-      })
-    })
-    .listen(port, err => {
-      if (err) {
-        pipeline.status(err, 'Cannot start: ' + err.message)
-      } else {
-        pipeline.status(null, `Listening on port ${port}.`)
-        console.log(`${name} listening on TCP port ${port}.`)
-      }
-    })
-}
-
-function createUdpServer ({pipeline, name, port, parse}) {
-  return dgram
-    .createSocket('udp4')
-    .on('message', message => {
-      try {
-        const result = syslogParse(message.toString())
-        pipeline.success(parse(result.message))
-      } catch (err) {
-        pipeline.error(err)
-      }
-    })
-    .on('error', err => {
-      pipeline.status(err, 'Cannot start: ' + err.message)
-    })
-    .on('listening', () => {
-      pipeline.status(null, `Listening on port ${port}.`)
-      console.log(`${name} listening on UDP port ${port}.`)
-    })
-    .bind(port)
-}
+const socket = require('./socket')
 
 const defaultParse = s => fromJS(JSON.parse(s))
 
@@ -58,11 +10,19 @@ function create ({name = 'Syslog', protocol, port = 514, parse = defaultParse}) 
   return {
     name: name,
     start: pipeline => {
+      const handler = message => {
+        try {
+          const result = syslogParse(message)
+          pipeline.success(parse(result.message))
+        } catch (err) {
+          pipeline.error(err)
+        }
+      }
       if (!protocol || protocol === 'udp') {
-        createUdpServer({pipeline, name, port, parse})
+        socket.createUdpServer({pipeline, name, port, handler})
       }
       if (!protocol || protocol === 'tcp') {
-        createTcpServer({pipeline, name, port, parse})
+        socket.createTcpServer({pipeline, name, port, handler})
       }
     }
   }

--- a/input/syslog.js
+++ b/input/syslog.js
@@ -1,26 +1,69 @@
-const syslogd = require('syslogd')
+const net = require('net')
+const dgram = require('dgram')
+
+const syslogParse = require('syslog-parse')
+
 const { fromJS } = require('immutable')
+
+function createTcpServer ({pipeline, name, port, parse}) {
+  return net
+    .createServer(socket => {
+      socket.on('data', data => {
+        data.toString().split('\n').forEach(line => {
+          if (line) {
+            try {
+              const result = syslogParse(line)
+              pipeline.success(parse(result.message))
+            } catch (err) {
+              pipeline.error(err)
+            }
+          }
+        })
+      })
+    })
+    .listen(port, err => {
+      if (err) {
+        pipeline.status(err, 'Cannot start: ' + err.message)
+      } else {
+        pipeline.status(null, `Listening on port ${port}.`)
+        console.log(`${name} listening on TCP port ${port}.`)
+      }
+    })
+}
+
+function createUdpServer ({pipeline, name, port, parse}) {
+  return dgram
+    .createSocket('udp4')
+    .on('message', message => {
+      try {
+        const result = syslogParse(message.toString())
+        pipeline.success(parse(result.message))
+      } catch (err) {
+        pipeline.error(err)
+      }
+    })
+    .on('error', err => {
+      pipeline.status(err, 'Cannot start: ' + err.message)
+    })
+    .on('listening', () => {
+      pipeline.status(null, `Listening on port ${port}.`)
+      console.log(`${name} listening on UDP port ${port}.`)
+    })
+    .bind(port)
+}
 
 const defaultParse = s => fromJS(JSON.parse(s))
 
-function create ({name = 'Syslog', port = 514, parse = defaultParse}) {
+function create ({name = 'Syslog', protocol, port = 514, parse = defaultParse}) {
   return {
     name: name,
-    start: (pipeline) => {
-      syslogd(message => {
-        try {
-          pipeline.success(parse(message.msg))
-        } catch (err) {
-          pipeline.error(err)
-        }
-      }).listen(port, err => {
-        if (err) {
-          pipeline.status(err, 'Cannot start: ' + err.message)
-        } else {
-          pipeline.status(null, `Listening on UDP port ${port}.`)
-          console.log(`${name} listening on UDP port ${port}.`)
-        }
-      })
+    start: pipeline => {
+      if (!protocol || protocol === 'udp') {
+        createUdpServer({pipeline, name, port, parse})
+      }
+      if (!protocol || protocol === 'tcp') {
+        createTcpServer({pipeline, name, port, parse})
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ajv": "^5.3.0",
     "axios": "^0.17.0",
     "body-parser": "^1.18.2",
+    "carrier": "^0.3.0",
     "date-format-lite": "^17.7.0",
     "ejs": "^2.5.7",
     "elasticsearch": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "ajv": "^5.3.0",
     "axios": "^0.17.0",
     "body-parser": "^1.18.2",
-    "carrier": "^0.3.0",
     "date-format-lite": "^17.7.0",
     "ejs": "^2.5.7",
     "elasticsearch": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "md5": "^2.2.1",
     "micro-strptime": "^0.2.2",
     "proxy-addr": "^2.0.2",
-    "syslogd": "^1.1.2",
+    "syslog-parse": "^1.3.1",
     "tail": "^1.2.3",
     "url": "^0.11.0",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Fix https://github.com/access-watch/access-watch/issues/87

 - Introduce a Socket input that can do UDP and TCP.
 - Base the Syslog input on it.
 - Remove syslogd dependency and use another module to parse syslog messages

Future improvements:
 - support chunked messages
 - support rfc5424 messages
