### PR TITLE
Cleanup database lifecycle functions.

### DIFF
--- a/dashboard/pipeline.js
+++ b/dashboard/pipeline.js
@@ -4,7 +4,7 @@ const { Map, fromJS } = require('immutable')
 const pipeline = require('../lib/pipeline')
 
 const reducers = require('../lib/reducers')
-const session = require('../lib/session').getDatabase('traffic')
+const session = require('../lib/session').connect('aw:file://sessions')
 const { FixedWindow } = require('../lib/window')
 
 const hub = require('../plugins/hub')

--- a/index.js
+++ b/index.js
@@ -1,13 +1,7 @@
-const path = require('path')
-
-// create the databases
-const session = require('./lib/session').createDatabase('traffic')
-const metrics = require('./lib/metrics').createDatabase('traffic')
-const rules = require('./lib/rules').createDatabase('traffic', {path: path.resolve(__dirname, 'data/rules.json')})
-
 // import the framework
 const app = require('./lib/app')
 const pipeline = require('./lib/pipeline')
+const database = require('./lib/database')
 
 // configure the application
 require('./config')
@@ -18,15 +12,12 @@ function start () {
   app.start()
 }
 
-start()
-
 // stop the application
 function stop () {
-  pipeline.close()
-  rules.close()
-  metrics.close()
-  session.close()
+  database.close()
   process.exit()
 }
+
+start()
 
 process.on('SIGINT', stop)

--- a/lib/app.js
+++ b/lib/app.js
@@ -3,9 +3,9 @@ const expressWs = require('express-ws')
 const bodyParser = require('body-parser')
 const { fromJS, Map } = require('immutable')
 
-const metrics = require('./metrics').getDatabase('traffic')
-const session = require('./session').getDatabase('traffic')
-const rules = require('./rules').getDatabase('traffic')
+const metrics = require('./metrics').connect('aw:file://metrics')
+const session = require('./session').connect('aw:file://sessions')
+const rules = require('./rules').connect('aw:file://rules')
 
 const pipeline = require('./pipeline')
 const { now, iso } = require('./util')

--- a/lib/database.js
+++ b/lib/database.js
@@ -8,13 +8,14 @@ const fs = require('fs')
 const connections = {}
 
 class Connection {
-  constructor (db) {
+  constructor (db, gcInterval) {
     this.db = db
+    this.gc = setInterval(function () {
+      this.db.gc()
+    }.bind(this), gcInterval)
   }
   close () {
-    if (this.db.close) {
-      this.db.close()
-    }
+    clearInterval(this.gc)
   }
 }
 
@@ -22,8 +23,8 @@ class Connection {
  * Connection to an in-memory database.
  */
 class InMemoryConnection extends Connection {
-  constructor (name, Klass) {
-    super(new Klass())
+  constructor (name, Klass, gcInterval) {
+    super(new Klass(), gcInterval)
   }
 }
 
@@ -54,9 +55,9 @@ function writeJSONFile (path, value) {
  * Connection to a database stored on a file in the `data` directory.
  */
 class FileConnection extends Connection {
-  constructor (name, Klass) {
+  constructor (name, Klass, gcInterval) {
     const filePath = path.resolve(__dirname, '../data/' + name + '.json')
-    super(Klass.deserialize(readJSONFile(filePath)))
+    super(Klass.deserialize(readJSONFile(filePath)), gcInterval)
     this.filePath = filePath
   }
 
@@ -74,7 +75,7 @@ class FileConnection extends Connection {
  *  'aw:mem://<name>'    In-memory store
  *  'aw:file://<name>'   Disk store Store (`data` directory)
  */
-function connect (uri, Klass) {
+function connect ({uri, Klass, gcInterval}) {
   if (connections.hasOwnProperty(uri)) {
     return connections[uri]
   }
@@ -82,10 +83,10 @@ function connect (uri, Klass) {
   let conn
   switch (protocol) {
     case 'aw:mem':
-      conn = new InMemoryConnection(name, Klass)
+      conn = new InMemoryConnection(name, Klass, gcInterval)
       break
     case 'aw:file':
-      conn = new FileConnection(name, Klass)
+      conn = new FileConnection(name, Klass, gcInterval)
       break
     default:
       throw new Error(`Unknown database protocol: ${protocol}`)

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,0 +1,112 @@
+/**
+ * Functions to manage the lifecycle of the databases.
+ */
+const path = require('path')
+const fs = require('fs')
+
+// cache the connections by uri
+const connections = {}
+
+class Connection {
+  constructor (db) {
+    this.db = db
+  }
+  close () {
+    if (this.db.close) {
+      this.db.close()
+    }
+  }
+}
+
+/**
+ * Connection to an in-memory database.
+ */
+class InMemoryConnection extends Connection {
+  constructor (name, Klass) {
+    super(new Klass())
+  }
+}
+
+/**
+ * Return the JSON content of the file at `path`, or null.
+ */
+function readJSONFile (path) {
+  try {
+    return JSON.parse(fs.readFileSync(path))
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      // file not found
+      return null
+    } else {
+      throw err
+    }
+  }
+}
+
+/**
+ * Write the Javascript value as a JSON file at `path`.
+ */
+function writeJSONFile (path, value) {
+  fs.writeFileSync(path, JSON.stringify(value, null, 2))
+}
+
+/**
+ * Connection to a database stored on a file in the `data` directory.
+ */
+class FileConnection extends Connection {
+  constructor (name, Klass) {
+    const filePath = path.resolve(__dirname, '../data/' + name + '.json')
+    super(Klass.deserialize(readJSONFile(filePath)))
+    this.filePath = filePath
+  }
+
+  close () {
+    super.close()
+    writeJSONFile(this.filePath, this.db.serialize())
+  }
+}
+
+/**
+ * Connect to the store specified by `uri`.
+ *
+ * The `uri` can be:
+ *
+ *  'aw:mem://<name>'    In-memory store
+ *  'aw:file://<name>'   Disk store Store (`data` directory)
+ */
+function connect (uri, Klass) {
+  if (connections.hasOwnProperty(uri)) {
+    return connections[uri]
+  }
+  let [protocol, name] = uri.split('://')
+  let conn
+  switch (protocol) {
+    case 'aw:mem':
+      conn = new InMemoryConnection(name, Klass)
+      break
+    case 'aw:file':
+      conn = new FileConnection(name, Klass)
+      break
+    default:
+      throw new Error(`Unknown database protocol: ${protocol}`)
+  }
+  connections[uri] = conn
+  return conn
+}
+
+/**
+ * Close all opened connections.
+ *
+ * Must be called when the process exits.
+ */
+function close () {
+  for (var uri in connections) {
+    connections[uri].close()
+    delete connections[uri]
+  }
+}
+
+module.exports = {
+  connect: connect,
+  close: close
+}

--- a/lib/database.js
+++ b/lib/database.js
@@ -73,7 +73,7 @@ class FileConnection extends Connection {
  * The `uri` can be:
  *
  *  'aw:mem://<name>'    In-memory store
- *  'aw:file://<name>'   Disk store Store (`data` directory)
+ *  'aw:file://<name>'   Filesystem store (`data` directory)
  */
 function connect ({uri, Klass, gcInterval}) {
   if (connections.hasOwnProperty(uri)) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -128,7 +128,7 @@ function filterAndAggregate (data, start, end, step) {
   return aggregate(data, start, end, step)
 }
 
-// Remove all points older than `cutoff`, retur number of removed elements
+// Remove all points older than `cutoff`, return the number of removed elements
 function gcPoints (points, cutoff) {
   const l = points.length
   for (var i = 0; i < l; i++) {
@@ -150,11 +150,10 @@ function gc (data, deleteAfter) {
   if (timeSeries.length > 0) {
     const now = Math.max.apply(null, timeSeries.map(a => (a.length) ? a[a.length - 1][0] : 0))
     const cutoff = now - deleteAfter
-    console.log('Garbage collecting events older than', iso(cutoff))
     const total = timeSeries
           .map(points => gcPoints(points, cutoff))
           .reduce((a, b) => a + b, 0)
-    console.log('Deleted', total, 'points.')
+    console.log(`Garbage collected ${total} points older than ${iso(cutoff)}.`)
   }
 }
 
@@ -162,13 +161,10 @@ class Database {
   constructor () {
     this.series = {}     // contains the points indexed by series
     this.indices = Map() // index the series by tags
-    this.gc = setInterval(function () {
-      gc(this.series, 24 * 3600)
-    }.bind(this), 3600 * 1000)
   }
 
-  close () {
-    clearInterval(this.gc)
+  gc () {
+    gc(this.series, 24 * 3600)
   }
 
   serialize () {
@@ -269,6 +265,15 @@ class Database {
   }
 }
 
+function connect (uri) {
+  const conn = database.connect({
+    uri: uri,
+    Klass: Database,
+    gcInterval: 3600 * 1000
+  })
+  return conn.db
+}
+
 module.exports = {
-  connect: (uri) => database.connect(uri, Database).db
+  connect: connect
 }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -11,7 +11,7 @@
 
 const { fromJS, Set, Map, isKeyed } = require('immutable')
 const { iso } = require('./util')
-const { PersistentObject } = require('./persist')
+const database = require('./database')
 
 // A time series is identified by a name and a set of named tags.
 function seriesFor (metric) {
@@ -159,50 +159,35 @@ function gc (data, deleteAfter) {
 }
 
 class Database {
-  /**
-   * Create a new in-memory time series database.
-   */
-  constructor ({deleteAfter = 24 * 3600, persist = true} = {}) {
-    if (persist) {
-      this.persist = new PersistentObject('metrics', this)
-      this.persist.read()
-    } else {
-      this.series = {}     // contains the points indexed by series
-      this.indices = Map() // index the series by tags
-    }
+  constructor () {
+    this.series = {}     // contains the points indexed by series
+    this.indices = Map() // index the series by tags
     this.gc = setInterval(function () {
-      gc(this.series, deleteAfter)
+      gc(this.series, 24 * 3600)
     }.bind(this), 3600 * 1000)
   }
 
-  /**
-   * Free any opened resources and finish background tasks.
-   */
   close () {
-    if (this.persist) {
-      this.persist.write()
-    }
     clearInterval(this.gc)
   }
 
-  load (data) {
-    if (!data) {
-      this.series = {}
-      this.indices = Map()
-    } else {
-      this.series = data.series
-      this.indices = fromJS(data.indices,
-                            function (key, value) {
-                              return isKeyed(value) ? value.toMap() : value.toSet()
-                            })
+  serialize () {
+    return {
+      series: this.series,
+      indices: this.indices.toJS()
     }
   }
 
-  unload () {
-    return {
-      series: this.series,
-      indices: this.indices
+  static deserialize (data) {
+    const db = new Database()
+    if (data) {
+      db.series = data.series
+      db.indices = fromJS(data.indices,
+                          function (key, value) {
+                            return isKeyed(value) ? value.toMap() : value.toSet()
+                          })
     }
+    return db
   }
 
   /**
@@ -284,17 +269,6 @@ class Database {
   }
 }
 
-const databases = {}
-
-function createDatabase (name, options) {
-  if (databases[name]) {
-    throw new Error('A database with the same name already exists.')
-  }
-  databases[name] = new Database(options)
-  return databases[name]
-}
-
 module.exports = {
-  createDatabase: (name, options) => createDatabase(name, options),
-  getDatabase: (name) => databases[name]
+  connect: (uri) => database.connect(uri, Database).db
 }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -13,9 +13,9 @@ const Ajv = require('ajv')
 const { Map, List } = require('immutable')
 const { now, complement, iso } = require('./util')
 
-const session = require('./session').getDatabase('traffic')
-const metrics = require('./metrics').getDatabase('traffic')
-const rules = require('./rules').getDatabase('traffic')
+const session = require('./session').connect('aw:file://sessions')
+const metrics = require('./metrics').connect('aw:file://metrics')
+const rules = require('./rules').connect('aw:file://rules')
 
 const schema = require('../format/log-schema.json')
 const validator = new Ajv()
@@ -431,10 +431,6 @@ class Pipeline extends Builder {
         status: monitor.status
       })
     })
-  }
-
-  close () {
-    rules.close()
   }
 }
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -12,9 +12,9 @@
  */
 const Ajv = require('ajv')
 const uuid = require('uuid/v4')
-const fs = require('fs')
 const { fromJS, Map } = require('immutable')
 const { now } = require('./util')
+const database = require('./database')
 
 const validator = new Ajv()
 
@@ -97,25 +97,22 @@ function validateRule (rule) {
 }
 
 class Database {
-  constructor ({path}) {
-    this.path = path
-    try {
-      fs.accessSync(path, fs.constants.F_OK)
-      const data = fromJS(JSON.parse(fs.readFileSync(path)))
-      this.rules = data.get('rules').map(data => createRule(data))
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        // no rules file
-        console.log('No rules file found. Creating a new database of rules.')
-        this.rules = Map()
-      } else {
-        throw err
-      }
+  constructor () {
+    this.rules = Map()
+  }
+
+  serialize () {
+    return {
+      rules: this.rules.toJS()
     }
   }
 
-  close () {
-    fs.writeFileSync(this.path, JSON.stringify({rules: this.rules}, null, 2))
+  static deserialize (data) {
+    const db = new Database()
+    if (data) {
+      this.rules = fromJS(data.rules)
+    }
+    return db
   }
 
   add (data) {
@@ -141,17 +138,6 @@ class Database {
   }
 }
 
-const databases = {}
-
-function createDatabase (name, options) {
-  if (databases[name]) {
-    throw new Error('A database with the same name already exists.')
-  }
-  databases[name] = new Database(options)
-  return databases[name]
-}
-
 module.exports = {
-  createDatabase: (name, options) => createDatabase(name, options),
-  getDatabase: (name) => databases[name]
+  connect: (uri) => database.connect(uri, Database).db
 }

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -101,6 +101,10 @@ class Database {
     this.rules = Map()
   }
 
+  gc () {
+    // noop for now
+  }
+
   serialize () {
     return {
       rules: this.rules.toJS()
@@ -138,6 +142,15 @@ class Database {
   }
 }
 
+function connect (uri) {
+  const conn = database.connect({
+    uri: uri,
+    Klass: Database,
+    gcInterval: 3600 * 1000
+  })
+  return conn.db
+}
+
 module.exports = {
-  connect: (uri) => database.connect(uri, Database).db
+  connect: connect
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -57,26 +57,17 @@ function size (sessions) {
   return sessions.reduce((total, sessions) => total + sessions.size, 0)
 }
 
-function gc (sessions) {
-  const cutoff = now() - 3600
-  console.log('Garbage collecting sessions older than', iso(cutoff))
-  const oldCount = size(sessions)
-  console.log(oldCount + ' sessions in the database.')
-  sessions = sessions.map(sessions => sessions.filter(s => s.get('end') >= cutoff))
-  console.log('Deleted', oldCount - size(sessions), 'sessions.')
-  return sessions
-}
-
 class Database {
   constructor () {
     this.sessions = Map()
-    this.gc = setInterval(function () {
-      this.sessions = gc(this.sessions)
-    }.bind(this), 3600 * 1000)
   }
 
-  close () {
-    clearInterval(this.gc)
+  gc () {
+    const cutoff = now() - 3600
+    const oldCount = size(this.sessions)
+    console.log(oldCount + ' sessions in the database.')
+    this.sessions = this.sessions.map(sessions => sessions.filter(s => s.get('end') >= cutoff))
+    console.log(`Garbage collected ${oldCount - size(this.sessions)} sessions older than ${iso(cutoff)}.`)
   }
 
   serialize () {
@@ -154,6 +145,15 @@ class Database {
   }
 }
 
+function connect (uri) {
+  const conn = database.connect({
+    uri: uri,
+    Klass: Database,
+    gcInterval: 3600 * 1000
+  })
+  return conn.db
+}
+
 module.exports = {
-  connect: (uri) => database.connect(uri, Database).db
+  connect: connect
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -4,7 +4,7 @@
 
 const { fromJS, Map, List, Range } = require('immutable')
 const { iso, now } = require('./util')
-const { PersistentObject } = require('./persist')
+const database = require('./database')
 
 /**
  * Helper to compute session speed.
@@ -68,39 +68,33 @@ function gc (sessions) {
 }
 
 class Database {
-  constructor ({persist = true} = {}) {
-    if (persist) {
-      this.persist = new PersistentObject('sessions', this)
-      this.persist.read()
-    } else {
-      this.sessions = Map()
-    }
+  constructor () {
+    this.sessions = Map()
     this.gc = setInterval(function () {
       this.sessions = gc(this.sessions)
     }.bind(this), 3600 * 1000)
   }
 
   close () {
-    if (this.persist) {
-      this.persist.write()
-    }
     clearInterval(this.gc)
   }
 
-  load (data) {
-    if (!data) {
-      this.sessions = Map()
-    } else {
-      this.sessions = fromJS(data).map(sessions => {
+  serialize () {
+    return {
+      sessions: this.sessions.toJS()
+    }
+  }
+
+  static deserialize (data) {
+    const db = new Database()
+    if (data) {
+      db.sessions = fromJS(data.sessions).map(sessions => {
         return sessions.map(session => {
           return session.update('speed', speed => new Speed(speed.get('size')))
         })
       })
     }
-  }
-
-  unload () {
-    return this.sessions
+    return db
   }
 
   // assign a session to an event
@@ -160,17 +154,6 @@ class Database {
   }
 }
 
-const databases = {}
-
-function createDatabase (name, options) {
-  if (databases[name]) {
-    throw new Error('A database with the same name already exists.')
-  }
-  databases[name] = new Database(options)
-  return databases[name]
-}
-
 module.exports = {
-  createDatabase: (name, options) => createDatabase(name, options),
-  getDatabase: (name) => databases[name]
+  connect: (uri) => database.connect(uri, Database).db
 }

--- a/test/lib/metrics.js
+++ b/test/lib/metrics.js
@@ -3,8 +3,9 @@
 const assert = require('assert')
 const { fromJS } = require('immutable')
 const metrics = require('../../lib/metrics.js')
+const database = require('../../lib/database.js')
 
-describe('Database', function () {
+describe('Metrics', function () {
   let db
 
   before(function () {
@@ -25,7 +26,7 @@ describe('Database', function () {
   })
 
   after(function () {
-    db.close()
+    database.close()
   })
 
   it('index by name', function () {

--- a/test/lib/metrics.js
+++ b/test/lib/metrics.js
@@ -8,7 +8,7 @@ describe('Database', function () {
   let db
 
   before(function () {
-    db = metrics.createDatabase('test', {persist: false})
+    db = metrics.connect('aw:mem://metrics')
     const metric = fromJS({
       name: 'request',
       time: 11,

--- a/test/lib/rules.js
+++ b/test/lib/rules.js
@@ -3,12 +3,17 @@
 const assert = require('assert')
 const { fromJS } = require('immutable')
 const rules = require('../../lib/rules.js')
+const database = require('../../lib/database.js')
 
 describe('Rules', function () {
   let db
 
   before(function () {
     db = rules.connect('aw:mem://rules')
+  })
+
+  after(function () {
+    database.close()
   })
 
   it('works', function () {

--- a/test/lib/rules.js
+++ b/test/lib/rules.js
@@ -1,15 +1,17 @@
 /* eslint-env mocha */
 
 const assert = require('assert')
-const fs = require('fs')
 const { fromJS } = require('immutable')
 const rules = require('../../lib/rules.js')
 
-const path = './test-rules.json'
-
 describe('Rules', function () {
+  let db
+
+  before(function () {
+    db = rules.connect('aw:mem://rules')
+  })
+
   it('works', function () {
-    const db = rules.createDatabase('test', {path: path})
     const rule1 = fromJS({
       id: '1',
       conditions: [
@@ -56,14 +58,5 @@ describe('Rules', function () {
 
     assert.equal(db.get('1').get('count'), 0)
     assert.equal(db.get('2').get('count'), 1)
-
-    db.close()
-    const newDb = rules.createDatabase('test2', {path: path})
-    newDb.match(log)
-
-    assert.equal(newDb.get('1').get('count'), 0)
-    assert.equal(newDb.get('2').get('count'), 2)
-
-    fs.unlinkSync(path)
   })
 })


### PR DESCRIPTION
There was a lot of repeated code to manage the lifecycle and the scheduling of the garbage collection of the various databases: sessions, metrics, and rules. I consolidated those functions in `lib/database`.

Now, each database has a connect function that takes a URI as parameter. Supported URIs:
* `aw:mem://<db-name>`: for in-memory databases (tests for example)
* `aw:file://<db-name>`: for databases persisted in the `./data` directory
